### PR TITLE
Заменить использование digitalWrite на analogWrite для режима DRIVER2WIRE_PWM для большей совместимости

### DIFF
--- a/src/GyverMotor2.h
+++ b/src/GyverMotor2.h
@@ -140,11 +140,11 @@ class GMotor2 {
 
             case DRIVER2WIRE_PWM:
                 if (dir > 0) {
-                    digitalWrite(pinA, 0);
+                    analogWrite(pinA, 0);
                     analogWrite(pinB, sp);
                 } else {
                     analogWrite(pinA, sp);
-                    digitalWrite(pinB, 0);
+                    analogWrite(pinB, 0);
                 }
                 break;
 
@@ -163,9 +163,16 @@ class GMotor2 {
 
     // установить все пины
     void setAll(uint8_t val) {
-        digitalWrite(pinA, val);
-        digitalWrite(pinB, val);
-        if (pinC != 255) digitalWrite(pinC, val);
+        if (GM_TYPE == DRIVER2WIRE_PWM){
+            if (val > 0) val = getMax();
+            
+            analogWrite(pinA, val);
+            analogWrite(pinB, val);
+        } else {
+            digitalWrite(pinA, val);
+            digitalWrite(pinB, val);
+            if (pinC != 255) digitalWrite(pinC, val);
+        }
         dir = 0;
     }
 


### PR DESCRIPTION
При работе с ESP32 (с [ядром от espressif](https://github.com/espressif/arduino-esp32)) вызов digitalWrite после analogWrite для одного и того же пина не делает ничего. В режиме DRIVER2WIRE_PWM такие вызовы чередуются, и библиотека работает некорректно (в остальных режимах такого чередования нет, и изменения не требуются).

Изменения:
 -  Для режима DRIVER2WIRE_PWM все вызовы digitalWrite заменены на analogWrite с аналогичным эффектом.

Также, если верить форумам, поведение при поочерёдных вызовах digitalWrite и analogWrite не определено вообще для любых МК, так что потенциально аналогичная проблема может возникать на любых других устройствах.

Пока протестированно только на ESP32.